### PR TITLE
Fixed toolbar buttons z-index

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 				top: 15px;
 				right: 30px;
 				text-align: right;
-
+				z-index:1000000';
 			}
 
 			#popup {


### PR DESCRIPTION
The toolbar buttons were not clickable because they were appearing behind the layer of the code. Now they are clickable.