### PR TITLE
hide wrapper-element when hiding code

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,7 +669,7 @@
 				if ( element.style.display === '' ) {
 
 					buttonHide.textContent = 'show code';
-
+					document.getElementById('editor').style.display = 'none'
 					element.style.display = 'none';
 					buttonUpdate.style.display = 'none';
 					buttonShare.display = 'none';
@@ -677,7 +677,7 @@
 				} else {
 
 					buttonHide.textContent = 'hide code';
-
+					document.getElementById('editor').style.display = 'block'
 					element.style.display = '';
 					buttonUpdate.style.display = '';
 					buttonShare.display = '';


### PR DESCRIPTION
it could be made better by saving the element into a var `var el = document.getElementById('editor')` and use that for toggeling `el.style.display='none'`. but i wanted to make minimal code-change :D - feel free to do it any other way and ignore this PR

fixes #10

http://guybrush.github.io/htmleditor/#B/dVVbT9swFH4uv+Kse5gZaZIhVUxtQWKlGw9UQ4A0+ugmp40hsTvHaSmI/75j5wKhXVTFJz6X79w7+nTxe3w3u55AYrL07GBUHp1RgjymszPK0HCIEq5zNKfdwix637uOkZttipbqzFW8hRdLdeY8elxqVci4F6lU6QF8Xrhn6NgZ10shBxCWn2qNepGqzQASEcco3e2rNR7U1kdB5cnIopTAkRYrA7mOTruJMatBEESxfMj9KFVFvEi5Rj9SWcAf+FOQinkemEQj+g95oPsn1UcmJF10zwjJmXtn+ezAurHmGiKeoeYe5BFK9ECjjFGjHtb8JSpKj956kHGDWvCUKMyTRiBTRY73cAqhV9IzSzfsjZCx2lzydGFlyi9fSIn6j4hNAgEc75GdfZC9RLFMTEtYSGFIalHIyAglgR1SfVzK6xiIK3EDd5c3k4k/5nLN85uKxQ6HLVGfKn8rnpHteujtc6RSj1VUZCiNbwvn89WKzI0TkcasSaQfq2ySopWyWk6tzHnLvWvU+QopkjWOHZfBSd/bm69ddzz4Rr+QntqxEsFfqVzY5PjPBNYPwwrf1boFf2tvWO1fXfN2Aos5/qoYDI5DKnf9qlHrDmnpTalZfvBcRNOKy+AFqsEJn0L32EA1LjR5PQCjC3x3cSXIlg19AMfw2uTQ9uAODtvTrrVzLmifx1Qbp1sbampIrMmaiCuRGxLVDL64fs5ohL94oORFJTm1t1O69WDB0xxrU6/u3TTkHgWGFqBp1GZ0GDgGTbeg4x56rbE5hK9U3eGbymxHZdZSmTUqb27ZkeFS2Kz8b2r+FpibcydDrJ82+azRaffuW2c9wZF1pgqlB7t864sf9vc3pu2xqn7cJBQNz1Zsx8gWjgijV+PYaF3b7cHb1ngeNXw5FR+GIlXq8dywcuM1ik2AzeCWBKs3YzW0rVrbHVStkipP1Qy9W7mjoNzqtOXt/84/